### PR TITLE
fix: timeout not awaited

### DIFF
--- a/src/FireblocksSigner.ts
+++ b/src/FireblocksSigner.ts
@@ -121,7 +121,7 @@ export class FireblocksSigner{
                 throw Error("Exiting the operation");
             }
             console.log((await this.apiClient.getTransactionById(txId)).status);
-            setTimeout(() => { }, 1000);
+            await new Promise((resolve) => setTimeout(resolve, 1000));
             
             status = await this.apiClient.getTransactionById(txId);
         }


### PR DESCRIPTION
The delay on checking the transction's status was inop, and needed to be awaited.

Proposed change now actually waits 4 seconds before querying the status again